### PR TITLE
ci: add explicit GITHUB_TOKEN permissions to workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ on:
     branches:
       - main
 
+# Restrict the default GITHUB_TOKEN to least privilege
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test on Node.js ${{ matrix.node-version }}
@@ -49,6 +53,12 @@ jobs:
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     
+    # Allow semantic-release to create releases, tags, and comment on PRs/issues
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -80,6 +90,11 @@ jobs:
     needs: [test, release]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     
+    # Enable GHA cache for docker buildx
+    permissions:
+      contents: read
+      actions: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -135,6 +150,11 @@ jobs:
     needs: docker
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     
+    # Required to upload SARIF to code scanning
+    permissions:
+      contents: read
+      security-events: write
+
     steps:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
       - beta
       - alpha
 
+# Restrict the default GITHUB_TOKEN to least privilege
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test on Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
This PR adds explicit least-privilege GITHUB_TOKEN permissions to satisfy Code Scanning (CodeQL) alerts for actions/missing-workflow-permissions.\n\nChanges:\n- Workflow-level permissions: contents: read (both workflows)\n- Job-level overrides:\n  - release: contents/issues/pull-requests: write (semantic-release)\n  - docker: actions: write; contents: read (buildx cache & gha cache)\n  - security: security-events: write; contents: read (upload SARIF)\n\nAfter merge, the 6 alerts should resolve on the next run.